### PR TITLE
Fix a race condition that can occur when returning to orbit

### DIFF
--- a/double_chest_farm.ahk
+++ b/double_chest_farm.ahk
@@ -335,15 +335,7 @@ F3:: ; main hotkey that runs the script
                 }
                 update_chest_ui()
             }
-            WinActivate, ahk_exe destiny2.exe ; make absolutely, positively, certain we are tabbed in
-            ; (not remaining=0 means OT L2 not reached. .. or .. not (remaining=40 and index>=20) means chest tracking broken but OT L2 not reached)
-            ; both conditions mean we do not have to orbit. simply reload.
-            if (!(remaining_chests <= 0 || (remaining_chests == 40 && A_Index >= 20)))
-            {
-                info_ui.update_content("Relaunching Landing")
-                reload_landing()
-            }
-            
+
             StopMonitoring(EXOTIC_PID)
             if (EXOTIC_DROP)
                 PLAYER_DATA[CURRENT_GUARDIAN]["ClassStats"]["current_exotics"]++
@@ -357,6 +349,18 @@ F3:: ; main hotkey that runs the script
             ; Decrease the remaining runs counter
             remaining_runs--
 
+
+            WinActivate, ahk_exe destiny2.exe ; make absolutely, positively, certain we are tabbed in
+            ; (not remaining=0 means OT L2 not reached. .. or .. not (remaining=40 and index>=20) means chest tracking broken but OT L2 not reached)
+            needs_orbit := (remaining_chests <= 0 || (remaining_chests == 40 && A_Index >= 20))
+
+            ; both conditions mean we do not have to orbit. simply reload.
+            if (!(needs_orbit || remaining_runs <= 0))
+            {
+                info_ui.update_content("Relaunching Landing")
+                reload_landing()
+            }
+            
             ; UI updates
             runs_till_orbit_ui.update_content("Runs till next orbit - " Ceil(remaining_chests/2))
             update_ui()
@@ -364,7 +368,7 @@ F3:: ; main hotkey that runs the script
             send_heartbeat()
             
             ; Break out to orbit if Overthrow L2
-            if (remaining_chests <= 0 || (remaining_chests == 40 && A_Index >= 20))
+            if (needs_orbit)
                 break
             ; Also break out if runs = 20 as fallback for not tracking chests
             if (remaining_runs <= 0)

--- a/double_chest_farm.ahk
+++ b/double_chest_farm.ahk
@@ -579,10 +579,9 @@ group_5_chests(chest_number:=21) ; picks up chest 21
     Send, % "{" key_binds["interact"] " Down}"
     PreciseSleep(1100)
     Send, % "{" key_binds["interact"] " Up}"
+    StopMonitoring(CHEST_PID)
     if (CHEST_OPENED)
         group_5_chest_opened := true
-    else 
-        StopMonitoring(CHEST_PID)
     CHEST_OPENED := false
     DllCall("mouse_event", uint, 1, int, -4400, int, -500)
     return group_5_chest_opened
@@ -885,10 +884,9 @@ group_4_chests(chest_number) ; picks up chests 16-20
         StartMonitoring(EXOTIC_PID)
         Send, % "{" key_binds["interact"] " Up}"
     }
+    StopMonitoring(CHEST_PID)
     if (CHEST_OPENED)
         group_4_chest_opened := true
-    else 
-        StopMonitoring(CHEST_PID)
     CHEST_OPENED := false
     return group_4_chest_opened
 }

--- a/monitor_loot.ahk
+++ b/monitor_loot.ahk
@@ -66,8 +66,8 @@ CheckChestOpen()
     	percent_white := exact_color_check("583|473|34|32", 34, 32, colors[A_Index]) ; checks for the circle around the interact prompt
     	if (percent_white > 0.01)
     	{
-        	PostMessage, 0x1003, 0, 0, , % "ahk_pid " main_pid
-        	SetTimer, CheckChestOpen, Off
+            SetTimer, CheckChestOpen, Off
+            PostMessage, 0x1003, 0, 0, , % "ahk_pid " main_pid
     	}
     }
     Return
@@ -82,8 +82,8 @@ CheckExoticDrop()
     pct_exotic_4 := exact_color_check("1258|438|20|80", 20, 80, 0xD8BD48)
     if (pct_exotic_1 > 0.01 || pct_exotic_2 > 0.01 || pct_exotic_3 > 0.01 || pct_exotic_4 > 0.01)
     {
-        PostMessage, 0x1004, 0, 0, , % "ahk_pid " main_pid
         SetTimer, CheckExoticDrop, Off
+        PostMessage, 0x1004, 0, 0, , % "ahk_pid " main_pid
     }
     Return
 }


### PR DESCRIPTION
The big change here is the first commit, which fixes an issue where `remaining_runs` could be decremented to 0 after `reload_landing()` has been called. This would cause a race condition where the player can spawn (closing the UI) while the macro is trying to return to orbit. The macro would eventually recover from it, but this saves it from having to go through the fail + recovery path.

Second commit is just some minor nits I found while going through the async messaging code ¯\\_(ツ)_/¯

